### PR TITLE
Expose GLES2 internal API

### DIFF
--- a/include/render/gles2.h
+++ b/include/render/gles2.h
@@ -112,24 +112,6 @@ struct wlr_gles2_buffer {
 	struct wlr_addon addon;
 };
 
-struct wlr_gles2_texture {
-	struct wlr_texture wlr_texture;
-	struct wlr_gles2_renderer *renderer;
-	struct wl_list link; // wlr_gles2_renderer.textures
-
-	GLenum target;
-
-	// If this texture is imported from a buffer, the texture is does not own
-	// these states. These cannot be destroyed along with the texture in this
-	// case.
-	GLuint tex;
-	GLuint fbo;
-
-	bool has_alpha;
-
-	uint32_t drm_format; // for mutable textures only, used to interpret upload data
-	struct wlr_gles2_buffer *buffer; // for DMA-BUF imports only
-};
 
 struct wlr_gles2_render_pass {
 	struct wlr_render_pass base;
@@ -155,14 +137,8 @@ struct wlr_gles2_renderer *gles2_get_renderer(
 	struct wlr_renderer *wlr_renderer);
 struct wlr_gles2_render_timer *gles2_get_render_timer(
 	struct wlr_render_timer *timer);
-struct wlr_gles2_texture *gles2_get_texture(
-	struct wlr_texture *wlr_texture);
 struct wlr_gles2_buffer *gles2_buffer_get_or_create(struct wlr_gles2_renderer *renderer,
-	struct wlr_buffer *wlr_buffer);
-
-struct wlr_texture *gles2_texture_from_buffer(struct wlr_renderer *wlr_renderer,
-	struct wlr_buffer *buffer);
-void gles2_texture_destroy(struct wlr_gles2_texture *texture);
+       struct wlr_buffer *wlr_buffer);
 
 void push_gles2_debug_(struct wlr_gles2_renderer *renderer,
 	const char *file, const char *func);

--- a/include/wlr/render/gles2.h
+++ b/include/wlr/render/gles2.h
@@ -48,4 +48,31 @@ bool wlr_texture_is_gles2(struct wlr_texture *texture);
 void wlr_gles2_texture_get_attribs(struct wlr_texture *texture,
 	struct wlr_gles2_texture_attribs *attribs);
 
+struct wlr_gles2_renderer;
+struct wlr_gles2_buffer;
+
+struct wlr_gles2_texture {
+       struct wlr_texture wlr_texture;
+       struct wlr_gles2_renderer *renderer;
+       struct wl_list link; /* wlr_gles2_renderer.textures */
+
+       GLenum target;
+
+       /* If this texture is imported from a buffer, the texture does not own
+        * these states. These cannot be destroyed along with the texture in this
+        * case. */
+       GLuint tex;
+       GLuint fbo;
+
+       bool has_alpha;
+
+       uint32_t drm_format; /* for mutable textures only, used to interpret upload data */
+       struct wlr_gles2_buffer *buffer; /* for DMA-BUF imports only */
+};
+
+struct wlr_gles2_texture *gles2_get_texture(struct wlr_texture *texture);
+struct wlr_texture *gles2_texture_from_buffer(struct wlr_renderer *renderer,
+       struct wlr_buffer *buffer);
+void gles2_texture_destroy(struct wlr_gles2_texture *texture);
+
 #endif

--- a/wlroots.syms
+++ b/wlroots.syms
@@ -2,6 +2,7 @@
 	global:
 		wlr_*;
 		_wlr_*;
+		gles2_*;
 	local:
 		*;
 };


### PR DESCRIPTION
## Summary
- expose GLES2 texture internals in the public header
- export `gles2_*` symbols
- remove duplicate declaration from the internal header

## Testing
- `meson setup build` *(fails: command not found)*
- `ninja -C build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686ee95f7aec832aa957c645cf80ebc5